### PR TITLE
add support for alpha package versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "package-json": "^6.5.0"
   },
   "devDependencies": {
+    "@types/node": "^17.0.12",
     "prettier": "^2.0.5",
     "typescript": "^3.9.6"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -19,6 +19,11 @@
   resolved "https://registry.yarnpkg.com/@types/color-name/-/color-name-1.1.1.tgz#1c1261bbeaa10a8055bbc5d8ab84b7b2afc846a0"
   integrity sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==
 
+"@types/node@^17.0.12":
+  version "17.0.12"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-17.0.12.tgz#f7aa331b27f08244888c47b7df126184bc2339c5"
+  integrity sha512-4YpbAsnJXWYK/fpTVFlMIcUIho2AYCi4wg5aNPrG1ng7fn/1/RZfCIpRCiBX+12RVa34RluilnvCqD+g3KiSiA==
+
 ansi-styles@^4.1.0:
   version "4.2.1"
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-4.2.1.tgz#90ae75c424d008d2624c5bf29ead3177ebfcf359"


### PR DESCRIPTION
*Issue #, if available:* [#5](https://github.com/cdk-dev/bump-cdk/issues/5)

*Description of changes:* 
Add support for alpha package versions e.g. `@aws-cdk/aws-synthetics-alpha` is set to `2.9.0-alpha.0`.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
